### PR TITLE
use debian 9 family

### DIFF
--- a/deploy/python/make_templates.py
+++ b/deploy/python/make_templates.py
@@ -43,7 +43,7 @@ def GenerateConfig(context):
             'boot': True,
             'autoDelete': True,
             'initializeParams': {
-                'sourceImage': 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180814'
+                'sourceImage': 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9'
               }
           }],
           'metadata': {

--- a/deploy/python/make_vms.py
+++ b/deploy/python/make_vms.py
@@ -41,7 +41,7 @@ def GenerateConfig(context):
           'boot': True,
           'autoDelete': True,
           'initializeParams': {
-              'sourceImage': 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180814'
+              'sourceImage': 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9'
             }
         }],
         'metadata': {


### PR DESCRIPTION
- Change python helpers that build vms to use debian-9 family and not a pinned version